### PR TITLE
feat: ajout de l'endpoint de suppression d'appel d'offre

### DIFF
--- a/Controllers/AppelOffreController.cs
+++ b/Controllers/AppelOffreController.cs
@@ -52,10 +52,29 @@ namespace Synoptis.API.Controllers
 
             if (newAppelOffre.Id == Guid.Empty) // sécurité en plus
                 return BadRequest("ID manquant dans la réponse");
-            Console.WriteLine($"ID généré : {newAppelOffre.Id}");
+
 
 
             return CreatedAtAction("GetAppelOffreById", new { id = newAppelOffre.Id }, newAppelOffre);
+
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<ActionResult<AppelOffreResponseDTO>> DeleteAppelOffreAsync(Guid id)
+        {
+            var appelOffreToDelete = await _appelOffreService.DeleteAppelOffreAsync(id);
+
+
+            if (appelOffreToDelete is null)
+            {
+                return NotFound(new { message = "Pas d'appel d'offre trouvé avec cet id" });
+            }
+
+            return Ok(new
+            {
+                message = $"L'appel d'offre : {appelOffreToDelete.Titre} a bien été supprimé",
+                data = appelOffreToDelete
+            });
 
         }
     }

--- a/Services/AppelOffreService.cs
+++ b/Services/AppelOffreService.cs
@@ -116,5 +116,36 @@ namespace Synoptis.API.Services
         }
 
 
+
+        // methode pour supprimer un AO 
+        public async Task<AppelOffreResponseDTO?> DeleteAppelOffreAsync(Guid id)
+        {
+            var appelOffreToDelete = await _context.AppelOffres.FindAsync(id);
+
+            if (appelOffreToDelete is null)
+            {
+                return null;
+            }
+
+            // je supprime de la bdd 
+            _context.AppelOffres.Remove(appelOffreToDelete);
+
+            // Je save le changement de maniere async
+            await _context.SaveChangesAsync();
+
+            // La je retourne un DTO en reponse (au front client)
+
+            return new AppelOffreResponseDTO
+            {
+                Id = appelOffreToDelete.Id,
+                Titre = appelOffreToDelete.Titre,
+                Description = appelOffreToDelete.Description,
+                NomClient = appelOffreToDelete.NomClient,
+                DateLimite = appelOffreToDelete.DateLimite,
+                CreeLe = appelOffreToDelete.CreeLe,
+                Statut = GetStringStatutFromEnum(appelOffreToDelete.Statut)
+            };
+        }
+
     }
 }

--- a/Services/Interfaces/IAppelOffreService.cs
+++ b/Services/Interfaces/IAppelOffreService.cs
@@ -13,5 +13,9 @@ namespace Synoptis.API.Services.Interfaces
 
         // Créer un nouvel AO à partir des données reçues du front en passant par les DTO
         Task<AppelOffreResponseDTO> CreateAppelOffreAsync(AppelOffreCreateDTO dto);
+
+        // Supprimer un AO grace a son id 
+        Task<AppelOffreResponseDTO?> DeleteAppelOffreAsync(Guid id);
+
     }
 }


### PR DESCRIPTION

## 🧠 Contexte
Ajout de la fonctionnalité permettant de supprimer un appel d’offre existant par son `id`.

## 🚀 Changements apportés
- Ajout d'une méthode `DeleteAppelOffreAsync` dans l'interface `IAppelOffreService`
- Implémentation dans le service
- Création de l'endpoint `[HttpDelete("{id}")]` dans le contrôleur
- Retourne un DTO au front avec un message de confirmation

## ✅ Comment tester ?
1. Lancer l’API
2. Envoyer une requête DELETE à `/api/ao/{id}`
3. Vérifier le message de succès ou l’erreur `404`

## 📌 Remarques
- La suppression est logique côté BDD (pas de soft delete ici)
- Un log pourrait être ajouté avec `ILogger` plus tard

